### PR TITLE
Update the year to be 2017 instead of 2016

### DIFF
--- a/freshers_signup.py
+++ b/freshers_signup.py
@@ -21,7 +21,7 @@ BANNER = """ W e l c o m e   t o
 / / / / //  __/ /_(__  ) /_/ / /__
 \/_/ /_/ \___/\__/____/\____/\___/
  \____/
-           F r e s h e r s '  2 0 1 6
+           F r e s h e r s '  2 0 1 7
 """
 
 def yes_no(prompt):


### PR DESCRIPTION
The previous year was 2016, as this is intended to be used at the upcoming freshers' week signups, it should be 2017 instead.
This PR should fix this error.